### PR TITLE
slightly changed the way we use subprocess and document output

### DIFF
--- a/check_references.py
+++ b/check_references.py
@@ -119,19 +119,21 @@ if __name__ == '__main__':
     print('--------------------------CERTIFYING----------------------------')
     print('----------------------------------------------------------------')
 
-    certify_command = ("crds certify --unique-errors-file "
-                       "certify_errored_files.txt "
-                       "--comparison-context={} {}").format(context, ' '.join(abs_paths))
+    certify_command = ("crds certify --all-errors-file certify_results.txt "
+                       "--comparison-context={} {}").format(context,
+                                                            ' '.join(abs_paths))
 
     shell_cmd = shlex.split(certify_command)    # Split the commmand string into a subprocess-friendly list
-    print(shell_cmd)                            # of "tokenized" arguments
-    
+    print(shell_cmd, '\n')                            # of "tokenized" arguments
+
     # Open a subprocess and make sure to recover standard output and standard error
     with subprocess.Popen(shell_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
-        output = p.communicate()[1].decode('utf-8')    # the output of communicate is a tuple (stdout_data, stderr_data) for
-    print(output)                                      # for some reason, Popen is setting the output of certify as the error...
-    
-    with open('certify_results.txt', mode= 'w+') as cert:
-        print(output, file= cert)
-        
+        out_dat, out_err = p.communicate()    # the output of communicate is a tuple (stdout_data, stderr_data)
+
+    print('{}\n{}'.format(out_dat.decode('utf-8'), out_err.decode('utf-8')))
+
+    with open('certify_results.txt', mode='a') as cert:
+        print('\n{}\n{}'.format(out_dat.decode('utf-8'), out_err.decode('utf-8')),
+            file=cert)
+
     check_certify_results(files)

--- a/rename_files.py
+++ b/rename_files.py
@@ -2,6 +2,7 @@ from astropy.io import fits
 import glob
 import sys
 import subprocess
+import shlex
 
 
 #-------------------------------------------------------------------------------
@@ -28,20 +29,20 @@ def rename_files(list_of_files):
                 break
             else:
                 print('\n {} IS COMPLIANT'.format(item))
-
+    string_list_of_files = ' '.join(list_of_files)
     # Run uniqname
-    uniqname = 'crds uniqname -s -a -r --files *.fits'
-    try:
-        output = subprocess.check_output(command)
-        print(output)
+    uniqname = 'crds uniqname --hst -s -a -r --files {}'.format(string_list_of_files)
+    rename_cmd = shlex.split(uniqname)
+
+    with subprocess.Popen(rename_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE) as p:
+        out_dat, out_err = p.communicate()
+
+    print('{}\n{}'.format(out_dat.decode('utf-8'), out_err.decode('utf-8')))
 
     # Document rename results in a log file
     with open('rename.log', mode= 'w+') as log:
-        print(output, file= log)
+        print('{}\n{}'.format(out_dat.decode('utf-8'), out_err.decode('utf-8')), file=log)
 
-    except subprocess.CalledProcessError as err:
-        print(err.returncode, err.output)
-        sys.exit()
 
     print('DONE. FILES RENAMED')
 


### PR DESCRIPTION
I've changed the way that we recover output from subprocess in that now we record the outdata and outerr and print both to the logs. I figured that this would be a good way to make sure that if the output we want changes from outerr to outdata for whatever reason. Plus it might make it easier to diagnose any issues that may come up. 

Also added the argument "--all-errors-file" to crds certify. Then I append the standard output at the end of that file. It could be that I don't understand completely how this works, but this way we'll capture everything in the log. 